### PR TITLE
Update AWS envoy image to 1.12.4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,7 @@ module "container_definition_xray" {
 module "container_definition_envoy" {
   source                       = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=0.23.0"
   container_name               = "envoy"
-  container_image              = "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.12.2.1-prod"
+  container_image              = "840364872350.dkr.ecr.eu-west-1.amazonaws.com/aws-appmesh-envoy:v1.12.4.0-prod"
   container_cpu                = var.envoy_cpu
   container_memory_reservation = var.envoy_memory
   container_memory             = var.envoy_memory


### PR DESCRIPTION
This PR updates the envoy sidecar proxy to use the 1.12.4 version of AWS provided envoy image